### PR TITLE
add sub spec for IDFA

### DIFF
--- a/SensorsAnalyticsSDK/SensorsAnalyticsSDK.podspec
+++ b/SensorsAnalyticsSDK/SensorsAnalyticsSDK.podspec
@@ -13,4 +13,13 @@ Pod::Spec.new do |s|
   s.libraries = 'icucore', 'sqlite3', 'z'
   s.platform = :ios, "7.0"
 
+  s.subspec 'IDFA' do |f|
+    f.source_files  = "SensorsAnalyticsSDK/SensorsAnalyticsSDK", "SensorsAnalyticsSDK/SensorsAnalyticsSDK/*.{h,m}"
+    f.public_header_files = "SensorsAnalyticsSDK/SensorsAnalyticsSDK/SensorsAnalyticsSDK.h"
+    f.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'CoreGraphics', 'QuartzCore'
+    f.libraries = 'icucore', 'sqlite3', 'z'
+    f.platform = :ios, "7.0"
+    f.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SENSORS_ANALYTICS_IDFA=1'}
+  end
+
 end


### PR DESCRIPTION
省去手动配置 `SENSORS_ANALYTICS_IDFA=1`，避免每次`pod install`或`pod update` 后都需要手动改回去