### PR TITLE
fix link error by adding CoreMotion framework

### DIFF
--- a/SensorsAnalyticsSDK/SensorsAnalyticsSDK.podspec
+++ b/SensorsAnalyticsSDK/SensorsAnalyticsSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author = { "Yuhan ZOU" => "zouyuhan@sensorsdata.cn" }
   s.platform = :ios, "7.0"
   s.default_subspec = 'core'
-  s.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'CoreGraphics', 'QuartzCore'
+  s.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'CoreGraphics', 'QuartzCore', 'CoreMotion'
   s.libraries = 'icucore', 'sqlite3', 'z'
 
   s.subspec 'core' do |c|


### PR DESCRIPTION
With `CLANG_ENABLE_MODULES` being `NO` we will get the build error below:

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_CMMotionManager", referenced from:
      objc-class-ref in libSensorsAnalyticsSDK.a(SADeviceOrientationManager.o)
```

It's good to declare dependencies explicitly.