### PR TITLE
fix(*): 修复[多线程环境下(APP启动时, 初始化后马上上报埋点), 获取用户自定义的动态公共属性可能为空(概率出现)];

### DIFF
--- a/SensorsAnalyticsSDK/SensorsAnalyticsSDK.m
+++ b/SensorsAnalyticsSDK/SensorsAnalyticsSDK.m
@@ -1502,9 +1502,11 @@ static SensorsAnalyticsSDK *sharedInstance = nil;
     if (lib_detail) {
         [libProperties setValue:lib_detail forKey:@"$lib_detail"];
     }
-    __block NSDictionary *dynamicSuperPropertiesDict = self.dynamicSuperProperties?self.dynamicSuperProperties():nil;
+    
     dispatch_async(self.serialQueue, ^{
         //获取用户自定义的动态公共属性
+        __block NSDictionary *dynamicSuperPropertiesDict = self.dynamicSuperProperties?self.dynamicSuperProperties():nil;
+        
         if (dynamicSuperPropertiesDict && [dynamicSuperPropertiesDict isKindOfClass:NSDictionary.class] == NO) {
             SALog(@"dynamicSuperProperties  returned: %@  is not an NSDictionary Obj.",dynamicSuperPropertiesDict);
             dynamicSuperPropertiesDict = nil;
@@ -1513,6 +1515,7 @@ static SensorsAnalyticsSDK *sharedInstance = nil;
                 dynamicSuperPropertiesDict = nil;
             }
         }
+        
         //去重
         [self unregisterSameLetterSuperProperties:dynamicSuperPropertiesDict];
 


### PR DESCRIPTION
issue: https://github.com/sensorsdata/sa-sdk-ios/issues/25