### PR TITLE
使用 < 和 > 导入 Framework Header

### DIFF
--- a/SensorsAnalyticsSDK/AppPush/SAConfigOptions+AppPush.h
+++ b/SensorsAnalyticsSDK/AppPush/SAConfigOptions+AppPush.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SAConfigOptions.h"
+#import <SAConfigOptions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/AutoTrack/SensorsAnalyticsSDK+SAAutoTrack.h
+++ b/SensorsAnalyticsSDK/AutoTrack/SensorsAnalyticsSDK+SAAutoTrack.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SensorsAnalyticsSDK/ChannelMatch/SensorsAnalyticsSDK+SAChannelMatch.h
+++ b/SensorsAnalyticsSDK/ChannelMatch/SensorsAnalyticsSDK+SAChannelMatch.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Core/SAConfigOptions.h
+++ b/SensorsAnalyticsSDK/Core/SAConfigOptions.h
@@ -19,8 +19,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SAStorePlugin.h"
-#import "SAConstants.h"
+#import <SAStorePlugin.h>
+#import <SAConstants.h>
 
 @class SASecretKey;
 @class SASecurityPolicy;

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK+Public.h
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK+Public.h
@@ -19,8 +19,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SAConstants.h"
-#import "SAPropertyPluginProtocol.h"
+#import <SAConstants.h>
+#import <SAPropertyPluginProtocol.h>
 
 @class SensorsAnalyticsPeople;
 @class SASecurityPolicy;

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.h
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.h
@@ -20,76 +20,76 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SensorsAnalyticsSDK+Public.h"
-#import "SASecurityPolicy.h"
-#import "SAConfigOptions.h"
-#import "SAConstants.h"
+#import <SensorsAnalyticsSDK+Public.h>
+#import <SASecurityPolicy.h>
+#import <SAConfigOptions.h>
+#import <SAConstants.h>
 
 
 //SensorsAnalyticsSDK section
-#if __has_include("SensorsAnalyticsSDK+SAChannelMatch.h")
-#import "SensorsAnalyticsSDK+SAChannelMatch.h"
+#if __has_include(<SensorsAnalyticsSDK+SAChannelMatch.h>)
+#import <SensorsAnalyticsSDK+SAChannelMatch.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+DebugMode.h")
-#import "SensorsAnalyticsSDK+DebugMode.h"
+#if __has_include(<SensorsAnalyticsSDK+DebugMode.h>)
+#import <SensorsAnalyticsSDK+DebugMode.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+Deeplink.h")
-#import "SensorsAnalyticsSDK+Deeplink.h"
+#if __has_include(<SensorsAnalyticsSDK+Deeplink.h>)
+#import <SensorsAnalyticsSDK+Deeplink.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+SAAutoTrack.h")
-#import "SensorsAnalyticsSDK+SAAutoTrack.h"
+#if __has_include(<SensorsAnalyticsSDK+SAAutoTrack.h>)
+#import <SensorsAnalyticsSDK+SAAutoTrack.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+Visualized.h")
-#import "SensorsAnalyticsSDK+Visualized.h"
+#if __has_include(<SensorsAnalyticsSDK+Visualized.h>)
+#import <SensorsAnalyticsSDK+Visualized.h>
 #endif
 
-#if __has_include("SASecretKey.h")
+#if __has_include(<SASecretKey.h>)
 #import "SASecretKey.h"
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+JavaScriptBridge.h")
-#import "SensorsAnalyticsSDK+JavaScriptBridge.h"
+#if __has_include(<SensorsAnalyticsSDK+JavaScriptBridge.h>)
+#import <SensorsAnalyticsSDK+JavaScriptBridge.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+DeviceOrientation.h")
-#import "SensorsAnalyticsSDK+DeviceOrientation.h"
+#if __has_include(<SensorsAnalyticsSDK+DeviceOrientation.h>)
+#import <SensorsAnalyticsSDK+DeviceOrientation.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+Location.h")
-#import "SensorsAnalyticsSDK+Location.h"
+#if __has_include(<SensorsAnalyticsSDK+Location.h>)
+#import <SensorsAnalyticsSDK+Location.h>
 #endif
 
 
 //configOptions section
 
-#if __has_include("SAConfigOptions+RemoteConfig.h")
-#import "SAConfigOptions+RemoteConfig.h"
+#if __has_include(<SAConfigOptions+RemoteConfig.h>)
+#import <SAConfigOptions+RemoteConfig.h>
 #endif
 
-#if __has_include("SAConfigOptions+Encrypt.h")
-#import "SAConfigOptions+Encrypt.h"
+#if __has_include(<SAConfigOptions+Encrypt.h>)
+#import <SAConfigOptions+Encrypt.h>
 #endif
 
-#if __has_include("SAConfigOptions+AppPush.h")
-#import "SAConfigOptions+AppPush.h"
+#if __has_include(<SAConfigOptions+AppPush.h>)
+#import <SAConfigOptions+AppPush.h>
 #endif
 
-#if __has_include("SAConfigOptions+Exception.h")
-#import "SAConfigOptions+Exception.h"
+#if __has_include(<SAConfigOptions+Exception.h>)
+#import <SAConfigOptions+Exception.h>
 #endif
 
 
-#if __has_include("SensorsAnalyticsSDK+WKWebView.h")
-#import "SensorsAnalyticsSDK+WKWebView.h"
+#if __has_include(<SensorsAnalyticsSDK+WKWebView.h>)
+#import <SensorsAnalyticsSDK+WKWebView.h>
 #endif
 
-#if __has_include("SensorsAnalyticsSDK+WebView.h")
+#if __has_include(<SensorsAnalyticsSDK+WebView.h>)
 #import "SensorsAnalyticsSDK+WebView.h"
 #endif
 
 
-#import "SAAESStorePlugin.h"
+#import <SAAESStorePlugin.h>

--- a/SensorsAnalyticsSDK/DebugMode/SensorsAnalyticsSDK+DebugMode.h
+++ b/SensorsAnalyticsSDK/DebugMode/SensorsAnalyticsSDK+DebugMode.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Deeplink/SensorsAnalyticsSDK+Deeplink.h
+++ b/SensorsAnalyticsSDK/Deeplink/SensorsAnalyticsSDK+Deeplink.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/DeviceOrientation/SensorsAnalyticsSDK+DeviceOrientation.h
+++ b/SensorsAnalyticsSDK/DeviceOrientation/SensorsAnalyticsSDK+DeviceOrientation.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Encrypt/SAConfigOptions+Encrypt.h
+++ b/SensorsAnalyticsSDK/Encrypt/SAConfigOptions+Encrypt.h
@@ -19,7 +19,7 @@
 //
 
 #import "SAEncryptProtocol.h"
-#import "SAConfigOptions.h"
+#import <SAConfigOptions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Exception/SAConfigOptions+Exception.h
+++ b/SensorsAnalyticsSDK/Exception/SAConfigOptions+Exception.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SAConfigOptions.h"
+#import <SAConfigOptions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/JSBridge/SensorsAnalyticsSDK+JavaScriptBridge.h
+++ b/SensorsAnalyticsSDK/JSBridge/SensorsAnalyticsSDK+JavaScriptBridge.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Location/SensorsAnalyticsSDK+Location.h
+++ b/SensorsAnalyticsSDK/Location/SensorsAnalyticsSDK+Location.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/RemoteConfig/SAConfigOptions+RemoteConfig.h
+++ b/SensorsAnalyticsSDK/RemoteConfig/SAConfigOptions+RemoteConfig.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SAConfigOptions.h"
+#import <SAConfigOptions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Store/SAAESStorePlugin.h
+++ b/SensorsAnalyticsSDK/Store/SAAESStorePlugin.h
@@ -19,7 +19,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SAStorePlugin.h"
+#import <SAStorePlugin.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Store/SABaseStoreManager.h
+++ b/SensorsAnalyticsSDK/Store/SABaseStoreManager.h
@@ -19,7 +19,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SAStorePlugin.h"
+#import <SAStorePlugin.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SensorsAnalyticsSDK/Visualized/SensorsAnalyticsSDK+Visualized.h
+++ b/SensorsAnalyticsSDK/Visualized/SensorsAnalyticsSDK+Visualized.h
@@ -18,7 +18,7 @@
 // limitations under the License.
 //
 
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SensorsAnalyticsSDK/WKWebView/SensorsAnalyticsSDK+WKWebView.h
+++ b/SensorsAnalyticsSDK/WKWebView/SensorsAnalyticsSDK+WKWebView.h
@@ -19,7 +19,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SensorsAnalyticsSDK.h"
+#import <SensorsAnalyticsSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
# 问题

我在尝试用同一个 Xcode 项目分别为 iOS 和 macOS App 引入神策 SDK，结果 `__has_include` 导致为 macOS 编译时引入了 iOS 相关代码。

# 调查

因为我们的 Xcode 项目文件本身也是通过工具从 Git 仓库生成的，因此没有使用 CocoaPods 或 SPM 等包管理器。我遇到的问题是在编译 macOS App 时，神策 SDK 编译报错：`UIKit is not available when building for macOS.`

我用一个最简项目复现了这个错误。

<img width="1400" alt="2022-02-15 15 56 44" src="https://user-images.githubusercontent.com/3415065/154018151-d785f6e2-07a5-4091-897c-f0db1a15442c.png">

根据 Xcode 提示，编译错误指向 `__has_include` 判断：

<img width="1400" alt="2022-02-15 16 00 39" src="https://user-images.githubusercontent.com/3415065/154018223-853ac3b9-4b00-499f-9ef8-557d8d7bb3da.png">

但通过截图可以看出，`SensorsAnalyticsSDK+SAAutoTrack.h` 并没有被添加到 macOS target 中。尽管这个文件存在，编译 macOS 相关 targets 时似乎不应该使用这个文件。

我怀疑 `__has_include` 作为 C flags 并不支持 Xcode 项目，因此仅仅检查文件是否存在，而非检查导入神策 SDK 的 Xcode 项目是否配置了相关编译阶段。（这个猜测后来被证明不准确。）

为了验证是否与 CocoaPods 有关我之前继承了 Pod target 的编译设置，当我把 Clang 编译器设置还原为 Xcode 默认值后，编译 iOS target 时出现 macOS 编译问题的代码位置同时有警告：`Double-quoted include in framework header, expected angle-bracketed instead.`

这让我怀疑 Clang 对 `""` 和 `<>` 语法导入的 header 处理不同。当使用 `""` 导入 header 时，Clang 会去搜索文件路径（应该会使用 System/User Header Search Paths），而使用 `<>` 导入 header 时，Clang 只会搜索项目（或框架）定义的 header。

当按照 Xcode 警告修改所有 header 语法后，macOS 项目也得以成功编译，`__has_include` 正常生效。