### PR TITLE
NSScreen 使用时未导入 AppKit

### DIFF
--- a/SensorsAnalyticsSDK/Core/PropertyPlugin/SAPresetPropertyPlugin.m
+++ b/SensorsAnalyticsSDK/Core/PropertyPlugin/SAPresetPropertyPlugin.m
@@ -31,6 +31,8 @@
 #import <UIKit/UIKit.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <CoreTelephony/CTCarrier.h>
+#elif TARGET_OS_OSX
+#import <AppKit/AppKit.h>
 #endif
 
 //中国运营商 mcc 标识


### PR DESCRIPTION
虽然使用 CocoaPods 没有问题，但直接编译会有报错。