### PR TITLE
fix:计时事件名称长度校验错误

### DIFF
--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
@@ -725,7 +725,8 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
 }
 
 - (void)trackTimerPause:(NSString *)event {
-    if (![self checkEventName:event]) {
+    NSString *eventName = [self.trackTimer eventNameFromEventId:event];
+    if (![self checkEventName:eventName]) {
         return;
     }
     UInt64 currentSysUpTime = [self.class getSystemUpTime];
@@ -735,7 +736,8 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
 }
 
 - (void)trackTimerResume:(NSString *)event {
-    if (![self checkEventName:event]) {
+    NSString *eventName = [self.trackTimer eventNameFromEventId:event];
+    if (![self checkEventName:eventName]) {
         return;
     }
     UInt64 currentSysUpTime = [self.class getSystemUpTime];
@@ -745,7 +747,8 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
 }
 
 - (void)removeTimer:(NSString *)event {
-    if (![self checkEventName:event]) {
+    NSString *eventName = [self.trackTimer eventNameFromEventId:event];
+    if (![self checkEventName:eventName]) {
         return;
     }
     dispatch_async(self.serialQueue, ^{


### PR DESCRIPTION
假设事件名称长度为70，加上后缀后，后缀长度为 45，长度超过100，无法通过校验，但是这个事件名其实是符合条件的。