### PR TITLE
watchOS 支持

### DIFF
--- a/SensorsAnalyticsSDK.podspec
+++ b/SensorsAnalyticsSDK.podspec
@@ -1,134 +1,169 @@
 Pod::Spec.new do |s|
-  s.name         = "SensorsAnalyticsSDK"
-  s.version      = "4.5.14"
-  s.summary      = "The official iOS SDK of Sensors Analytics."
-  s.homepage     = "http://www.sensorsdata.cn"
-  s.source       = { :git => 'https://github.com/sensorsdata/sa-sdk-ios.git', :tag => "v#{s.version}" }
+  s.name = "SensorsAnalyticsSDK"
+  s.version = "4.5.14"
+  s.summary = "The official iOS SDK of Sensors Analytics."
+  s.homepage = "http://www.sensorsdata.cn"
+  s.source = { :git => "https://github.com/sensorsdata/sa-sdk-ios.git", :tag => "v#{s.version}" }
   s.license = { :type => "Apache License, Version 2.0" }
   s.author = { "Yuhan ZOU" => "zouyuhan@sensorsdata.cn" }
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.13'
-  s.default_subspec = 'Core'
-  s.frameworks = 'Foundation', 'SystemConfiguration'
 
-  s.libraries = 'icucore', 'z'
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.13"
+  s.watchos.deployment_target = "7.0"
 
-  s.subspec '__Store' do |ss|
-    ss.source_files = 'SensorsAnalyticsSDK/Store/*.{h,m}'
-    ss.public_header_files = 'SensorsAnalyticsSDK/Store/SABaseStoreManager.h', 'SensorsAnalyticsSDK/Store/SAStorePlugin.h', 'SensorsAnalyticsSDK/Store/SAAESStorePlugin.h'
+  s.default_subspec = "Core"
+
+  s.subspec "__Store" do |ss|
+    ss.source_files = "SensorsAnalyticsSDK/Store/*.{h,m}"
+    ss.public_header_files = [
+      "SensorsAnalyticsSDK/Store/SABaseStoreManager.h",
+      "SensorsAnalyticsSDK/Store/SAStorePlugin.h",
+      "SensorsAnalyticsSDK/Store/SAAESStorePlugin.h",
+    ]
   end
 
-  s.subspec 'Base' do |b|
-    core_dir = "SensorsAnalyticsSDK/Core/"
-    b.source_files = core_dir + "**/*.{h,m}"
-    b.exclude_files = core_dir + "SAAlertController.h", core_dir + "SAAlertController.m"
-    b.public_header_files = core_dir + "SensorsAnalyticsSDK.h", core_dir + "SensorsAnalyticsSDK+Public.h", core_dir + "SASecurityPolicy.h", core_dir + "SAConfigOptions.h", core_dir + "SAConstants.h", core_dir + "PropertyPlugin/SAPropertyPlugin.h"
-    b.ios.frameworks = 'CoreTelephony'
-    b.dependency 'SensorsAnalyticsSDK/__Store'
+  s.subspec "Base" do |b|
+    b.source_files = "SensorsAnalyticsSDK/Core/**/*.{h,m}"
+    b.exclude_files = "SensorsAnalyticsSDK/Core/SAAlertController.{h,m}"
+    b.public_header_files = [
+      "SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.h",
+      "SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK+Public.h",
+      "SensorsAnalyticsSDK/Core/SASecurityPolicy.h",
+      "SensorsAnalyticsSDK/Core/SAConfigOptions.h",
+      "SensorsAnalyticsSDK/Core/SAConstants.h",
+      "SensorsAnalyticsSDK/Core/PropertyPlugin/SAPropertyPlugin.h",
+    ]
+
+    b.ios.frameworks = "CoreTelephony", "SystemConfiguration"
+    b.osx.frameworks = "SystemConfiguration"
+    b.watchos.frameworks = "WatchKit"
+
+    b.dependency "SensorsAnalyticsSDK/__Store"
   end
 
-  s.subspec 'Extension' do |e|
-    e.dependency 'SensorsAnalyticsSDK/Base'
+  s.subspec "Extension" do |e|
+    e.dependency "SensorsAnalyticsSDK/Base"
   end
 
-  s.subspec 'Common' do |c|
-    c.dependency 'SensorsAnalyticsSDK/Extension'
-    c.public_header_files = 'SensorsAnalyticsSDK/JSBridge/SensorsAnalyticsSDK+JavaScriptBridge.h'
-    c.source_files = 'SensorsAnalyticsSDK/Core/SAAlertController.{h,m}', 'SensorsAnalyticsSDK/JSBridge/**/*.{h,m}'
-    c.ios.source_files = 'SensorsAnalyticsSDK/RemoteConfig/**/*.{h,m}', 'SensorsAnalyticsSDK/ChannelMatch/**/*.{h,m}', 'SensorsAnalyticsSDK/Encrypt/**/*.{h,m}', 'SensorsAnalyticsSDK/Deeplink/**/*.{h,m}', 'SensorsAnalyticsSDK/DebugMode/**/*.{h,m}', 'SensorsAnalyticsSDK/Core/SAAlertController.h', 'SensorsAnalyticsSDK/UIRelated/**/*.{h,m}'
-    c.ios.public_header_files = 'SensorsAnalyticsSDK/{Encrypt,RemoteConfig,ChannelMatch,Deeplink,DebugMode}/{SAConfigOptions,SensorsAnalyticsSDK}+*.h', 'SensorsAnalyticsSDK/Encrypt/SAEncryptProtocol.h', 'SensorsAnalyticsSDK/Encrypt/SASecretKey.h', 'SensorsAnalyticsSDK/Deeplink/SASlinkCreator.h', 'SensorsAnalyticsSDK/UIRelated/UIView+SensorsAnalytics.h'
+  s.subspec "Common" do |c|
+    c.source_files = [
+      "SensorsAnalyticsSDK/Core/SAAlertController.{h,m}",
+      "SensorsAnalyticsSDK/JSBridge/**/*.{h,m}",
+    ]
+    c.public_header_files = "SensorsAnalyticsSDK/JSBridge/SensorsAnalyticsSDK+JavaScriptBridge.h"
+
+    c.ios.source_files = [
+      "SensorsAnalyticsSDK/RemoteConfig/**/*.{h,m}",
+      "SensorsAnalyticsSDK/ChannelMatch/**/*.{h,m}",
+      "SensorsAnalyticsSDK/Encrypt/**/*.{h,m}",
+      "SensorsAnalyticsSDK/Deeplink/**/*.{h,m}",
+      "SensorsAnalyticsSDK/DebugMode/**/*.{h,m}",
+      "SensorsAnalyticsSDK/UIRelated/**/*.{h,m}",
+    ]
+    c.ios.public_header_files = [
+      "SensorsAnalyticsSDK/{Encrypt,RemoteConfig,ChannelMatch,Deeplink,DebugMode}/{SAConfigOptions,SensorsAnalyticsSDK}+*.h",
+      "SensorsAnalyticsSDK/Encrypt/SAEncryptProtocol.h",
+      "SensorsAnalyticsSDK/Encrypt/SASecretKey.h",
+      "SensorsAnalyticsSDK/Deeplink/SASlinkCreator.h",
+      "SensorsAnalyticsSDK/UIRelated/UIView+SensorsAnalytics.h",
+    ]
+
+    c.dependency "SensorsAnalyticsSDK/Extension"
   end
 
-  s.subspec 'Core' do |c|
-    c.ios.dependency 'SensorsAnalyticsSDK/Visualized'
-    c.osx.dependency 'SensorsAnalyticsSDK/Common'
+  s.subspec "Core" do |c|
+    c.ios.dependency "SensorsAnalyticsSDK/Visualized"
+    c.osx.dependency "SensorsAnalyticsSDK/Common"
+    c.watchos.dependency "SensorsAnalyticsSDK/Base"
   end
 
   # 全埋点
-  s.subspec 'AutoTrack' do |g|
-    g.ios.deployment_target = '9.0'
-    g.dependency 'SensorsAnalyticsSDK/Common'
+  s.subspec "AutoTrack" do |g|
+    g.ios.deployment_target = "9.0"
+    g.dependency "SensorsAnalyticsSDK/Common"
     g.source_files = "SensorsAnalyticsSDK/AutoTrack/**/*.{h,m}"
-    g.public_header_files = 'SensorsAnalyticsSDK/AutoTrack/SensorsAnalyticsSDK+SAAutoTrack.h', 'SensorsAnalyticsSDK/AutoTrack/SAConfigOptions+AutoTrack.h'
-    g.frameworks = 'UIKit'
+    g.public_header_files = "SensorsAnalyticsSDK/AutoTrack/SensorsAnalyticsSDK+SAAutoTrack.h", "SensorsAnalyticsSDK/AutoTrack/SAConfigOptions+AutoTrack.h"
+    g.frameworks = "UIKit"
   end
 
-# 可视化相关功能，包含可视化全埋点和点击图
-  s.subspec 'Visualized' do |f|
-    f.ios.deployment_target = '9.0'
-    f.dependency 'SensorsAnalyticsSDK/AutoTrack'
+  # 可视化相关功能，包含可视化全埋点和点击图
+  s.subspec "Visualized" do |f|
+    f.ios.deployment_target = "9.0"
+    f.dependency "SensorsAnalyticsSDK/AutoTrack"
     f.source_files = "SensorsAnalyticsSDK/Visualized/**/*.{h,m}"
-    f.public_header_files = 'SensorsAnalyticsSDK/Visualized/SensorsAnalyticsSDK+Visualized.h', 'SensorsAnalyticsSDK/Visualized/SAConfigOptions+Visualized.h'
+    f.public_header_files = "SensorsAnalyticsSDK/Visualized/SensorsAnalyticsSDK+Visualized.h", "SensorsAnalyticsSDK/Visualized/SAConfigOptions+Visualized.h"
   end
 
   # 开启 GPS 定位采集
-  s.subspec 'Location' do |f|
-    f.ios.deployment_target = '9.0'
-    f.frameworks = 'CoreLocation'
-    f.dependency 'SensorsAnalyticsSDK/Core'
+  s.subspec "Location" do |f|
+    f.ios.deployment_target = "9.0"
+    f.frameworks = "CoreLocation"
+    f.dependency "SensorsAnalyticsSDK/Core"
     f.source_files = "SensorsAnalyticsSDK/Location/**/*.{h,m}"
-    f.public_header_files = 'SensorsAnalyticsSDK/Location/SensorsAnalyticsSDK+Location.h'
+    f.public_header_files = "SensorsAnalyticsSDK/Location/SensorsAnalyticsSDK+Location.h"
   end
 
   # 开启设备方向采集
-  s.subspec 'DeviceOrientation' do |f|
-    f.ios.deployment_target = '9.0'
-    f.dependency 'SensorsAnalyticsSDK/Core'
-    f.source_files = 'SensorsAnalyticsSDK/DeviceOrientation/**/*.{h,m}'
-    f.public_header_files = 'SensorsAnalyticsSDK/DeviceOrientation/SensorsAnalyticsSDK+DeviceOrientation.h'
-    f.frameworks = 'CoreMotion'
+  s.subspec "DeviceOrientation" do |f|
+    f.ios.deployment_target = "9.0"
+    f.dependency "SensorsAnalyticsSDK/Core"
+    f.source_files = "SensorsAnalyticsSDK/DeviceOrientation/**/*.{h,m}"
+    f.public_header_files = "SensorsAnalyticsSDK/DeviceOrientation/SensorsAnalyticsSDK+DeviceOrientation.h"
+    f.frameworks = "CoreMotion"
   end
 
   # 推送点击
-  s.subspec 'AppPush' do |f|
-    f.ios.deployment_target = '9.0'
-    f.dependency 'SensorsAnalyticsSDK/Core'
+  s.subspec "AppPush" do |f|
+    f.ios.deployment_target = "9.0"
+    f.dependency "SensorsAnalyticsSDK/Core"
     f.source_files = "SensorsAnalyticsSDK/AppPush/**/*.{h,m}"
-    f.public_header_files = 'SensorsAnalyticsSDK/AppPush/SAConfigOptions+AppPush.h'
+    f.public_header_files = "SensorsAnalyticsSDK/AppPush/SAConfigOptions+AppPush.h"
   end
 
   # 使用崩溃事件采集
-  s.subspec 'Exception' do |e|
-    e.ios.deployment_target = '9.0'
-    e.dependency 'SensorsAnalyticsSDK/Common'
-    e.source_files  =  "SensorsAnalyticsSDK/Exception/**/*.{h,m}"
-    e.public_header_files = 'SensorsAnalyticsSDK/Exception/SAConfigOptions+Exception.h'
+  s.subspec "Exception" do |e|
+    e.ios.deployment_target = "9.0"
+    e.dependency "SensorsAnalyticsSDK/Common"
+    e.source_files = "SensorsAnalyticsSDK/Exception/**/*.{h,m}"
+    e.public_header_files = "SensorsAnalyticsSDK/Exception/SAConfigOptions+Exception.h"
   end
 
   # 基于 UA，使用 UIWebView 或者 WKWebView 进行打通
-  s.subspec 'WebView' do |w|
-    w.ios.deployment_target = '9.0'
-    w.dependency 'SensorsAnalyticsSDK/Core'
-    w.source_files  =  "SensorsAnalyticsSDK/WebView/**/*.{h,m}"
-    w.public_header_files = 'SensorsAnalyticsSDK/WebView/SensorsAnalyticsSDK+WebView.h'
+  s.subspec "WebView" do |w|
+    w.ios.deployment_target = "9.0"
+    w.dependency "SensorsAnalyticsSDK/Core"
+    w.source_files = "SensorsAnalyticsSDK/WebView/**/*.{h,m}"
+    w.public_header_files = "SensorsAnalyticsSDK/WebView/SensorsAnalyticsSDK+WebView.h"
   end
 
   # 基于 UA，使用 WKWebView 进行打通
-  s.subspec 'WKWebView' do |w|
-    w.ios.deployment_target = '9.0'
-    w.dependency 'SensorsAnalyticsSDK/Core'
-    w.source_files  =  "SensorsAnalyticsSDK/WKWebView/**/*.{h,m}"
-    w.public_header_files = 'SensorsAnalyticsSDK/WKWebView/SensorsAnalyticsSDK+WKWebView.h'
+  s.subspec "WKWebView" do |w|
+    w.ios.deployment_target = "9.0"
+    w.dependency "SensorsAnalyticsSDK/Core"
+    w.source_files = "SensorsAnalyticsSDK/WKWebView/**/*.{h,m}"
+    w.public_header_files = "SensorsAnalyticsSDK/WKWebView/SensorsAnalyticsSDK+WKWebView.h"
   end
 
-  s.subspec 'ApplicationExtension' do |e|
-    e.dependency 'SensorsAnalyticsSDK/Extension'
-  	e.source_files = 'SensorsAnalyticsSDK/AppExtension/*.{h,m}'
-  	e.public_header_files = 'SensorsAnalyticsSDK/AppExtension/SensorsAnalyticsSDK+SAAppExtension.h'
+  s.subspec "ApplicationExtension" do |e|
+    e.dependency "SensorsAnalyticsSDK/Extension"
+    e.source_files = "SensorsAnalyticsSDK/AppExtension/*.{h,m}"
+    e.public_header_files = "SensorsAnalyticsSDK/AppExtension/SensorsAnalyticsSDK+SAAppExtension.h"
   end
 
-  s.subspec 'DeprecatedCellClick' do |d|
-    d.ios.deployment_target = '9.0'
-    d.dependency 'SensorsAnalyticsSDK/Core'
-    d.source_files = 'CellClick_HookDelegate_Deprecated/*.{h,m}'
-    d.project_header_files = 'CellClick_HookDelegate_Deprecated/*.h'
+  s.subspec "DeprecatedCellClick" do |d|
+    d.ios.deployment_target = "9.0"
+    d.dependency "SensorsAnalyticsSDK/Core"
+    d.source_files = "CellClick_HookDelegate_Deprecated/*.{h,m}"
+    d.project_header_files = "CellClick_HookDelegate_Deprecated/*.h"
   end
 
-  s.subspec 'Exposure' do |h|
-    h.ios.deployment_target = '9.0'
-    h.dependency 'SensorsAnalyticsSDK/Common'
-    h.source_files = 'SensorsAnalyticsSDK/Exposure/**/*.{h,m}'
-    h.public_header_files = 'SensorsAnalyticsSDK/Exposure/SAConfigOptions+Exposure.h', 'SensorsAnalyticsSDK/Exposure/SAExposureConfig.h', 'SensorsAnalyticsSDK/Exposure/SAExposureData.h', 'SensorsAnalyticsSDK/Exposure/SensorsAnalyticsSDK+Exposure.h', 'SensorsAnalyticsSDK/Exposure/UIView+ExposureIdentifier.h', 'SensorsAnalyticsSDK/Exposure/SAExposureListener.h'
+  s.subspec "Exposure" do |h|
+    h.ios.deployment_target = "9.0"
+    h.dependency "SensorsAnalyticsSDK/Common"
+    h.source_files = "SensorsAnalyticsSDK/Exposure/**/*.{h,m}"
+    h.public_header_files = "SensorsAnalyticsSDK/Exposure/SAConfigOptions+Exposure.h", "SensorsAnalyticsSDK/Exposure/SAExposureConfig.h", "SensorsAnalyticsSDK/Exposure/SAExposureData.h", "SensorsAnalyticsSDK/Exposure/SensorsAnalyticsSDK+Exposure.h", "SensorsAnalyticsSDK/Exposure/UIView+ExposureIdentifier.h", "SensorsAnalyticsSDK/Exposure/SAExposureListener.h"
   end
 
+  s.frameworks = "Foundation"
+  s.libraries = "icucore", "z"
 end

--- a/SensorsAnalyticsSDK/Core/Builder/EventObject/SAEventLibObject.m
+++ b/SensorsAnalyticsSDK/Core/Builder/EventObject/SAEventLibObject.m
@@ -43,7 +43,8 @@ NSString * const kSAEventPresetPropertyAppVersion = @"$app_version";
 - (instancetype)init {
     self = [super init];
     if (self) {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
+        // FIXME: If supported, report "watchOS".
         _lib = @"iOS";
 #elif TARGET_OS_OSX
         _lib = @"macOS";

--- a/SensorsAnalyticsSDK/Core/Builder/SAPresetPropertyObject.h
+++ b/SensorsAnalyticsSDK/Core/Builder/SAPresetPropertyObject.h
@@ -55,4 +55,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 #endif
 
+#if TARGET_OS_WATCH
+@interface SAWatchPresetProperty : SAPresetPropertyObject
+
+@end
+#endif
+
 NS_ASSUME_NONNULL_END

--- a/SensorsAnalyticsSDK/Core/Builder/SAPresetPropertyObject.m
+++ b/SensorsAnalyticsSDK/Core/Builder/SAPresetPropertyObject.m
@@ -32,6 +32,8 @@
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+#elif TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
 #endif
 
 @implementation SAPresetPropertyObject
@@ -241,6 +243,38 @@ NSString * const kSAEventPresetPropertyPluginLib = @"$lib";
 
 - (NSInteger)screenWidth {
     return (NSInteger)NSScreen.mainScreen.frame.size.width;
+}
+
+@end
+#endif
+
+#if TARGET_OS_WATCH
+@implementation SAWatchPresetProperty
+
+- (NSString *)deviceModel {
+    return [self sysctlByName:@"hw.machine"];
+}
+
+- (NSString *)lib {
+    // FIXME: If supported, report "watchOS".
+    return @"iOS";
+}
+
+- (NSString *)os {
+    // FIXME: If supported, report "watchOS".
+    return @"iOS";
+}
+
+- (NSString *)osVersion {
+    return [[WKInterfaceDevice currentDevice] systemVersion];
+}
+
+- (NSInteger)screenHeight {
+    return (NSInteger)[WKInterfaceDevice currentDevice].screenBounds.size.height;
+}
+
+- (NSInteger)screenWidth {
+    return (NSInteger)[WKInterfaceDevice currentDevice].screenBounds.size.width;
 }
 
 @end

--- a/SensorsAnalyticsSDK/Core/Network/SANetworkInfoPropertyPlugin.m
+++ b/SensorsAnalyticsSDK/Core/Network/SANetworkInfoPropertyPlugin.m
@@ -141,6 +141,7 @@ static NSString * const kSAEventPresetPropertyWifi = @"$wifi";
 #endif
 
 - (NSString *)networkTypeString {
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
     NSString *networkTypeString = @"NULL";
     @try {
         if ([SAReachability sharedInstance].isReachableViaWiFi) {
@@ -155,6 +156,9 @@ static NSString * const kSAEventPresetPropertyWifi = @"$wifi";
         SALogError(@"%@: %@", self, exception);
     }
     return networkTypeString;
+#else
+    return @"WIFI";
+#endif
 }
 
 #pragma mark - public method

--- a/SensorsAnalyticsSDK/Core/Network/SAReachability.h
+++ b/SensorsAnalyticsSDK/Core/Network/SAReachability.h
@@ -18,6 +18,8 @@
 // limitations under the License.
 //
 
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
+
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
@@ -50,3 +52,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/SensorsAnalyticsSDK/Core/Network/SAReachability.m
+++ b/SensorsAnalyticsSDK/Core/Network/SAReachability.m
@@ -18,6 +18,8 @@
 // limitations under the License.
 //
 
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
+
 #if ! __has_feature(objc_arc)
 #error This file must be compiled with ARC. Either turn on ARC for the project or use -fobjc-arc flag on this file.
 #endif
@@ -214,3 +216,5 @@ static void SAReachabilityReleaseCallback(const void *info) {
 }
 
 @end
+
+#endif

--- a/SensorsAnalyticsSDK/Core/PropertyPlugin/PresetProperty/SAPresetPropertyPlugin.m
+++ b/SensorsAnalyticsSDK/Core/PropertyPlugin/PresetProperty/SAPresetPropertyPlugin.m
@@ -64,6 +64,8 @@
     }
 #elif TARGET_OS_OSX
     propertyObject = [[SAMacPresetProperty alloc] init];
+#elif TARGET_OS_WATCH
+    propertyObject = [[SAWatchPresetProperty alloc] init];
 #endif
 
     NSMutableDictionary<NSString *, id> *properties = [NSMutableDictionary dictionary];

--- a/SensorsAnalyticsSDK/Core/SAConfigOptions.m
+++ b/SensorsAnalyticsSDK/Core/SAConfigOptions.m
@@ -155,7 +155,7 @@ static const NSUInteger kSASessionMaxInterval = 5 * 60;
     options.propertyPlugins = self.propertyPlugins;
     options.instantEvents = self.instantEvents;
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
     // 支持 https 自签证书
     options.securityPolicy = [self.securityPolicy copy];
 

--- a/SensorsAnalyticsSDK/Core/SAKeyChainItemWrapper.h
+++ b/SensorsAnalyticsSDK/Core/SAKeyChainItemWrapper.h
@@ -23,7 +23,6 @@
 extern  NSString * const kSAService;
 extern  NSString * const kSAUdidAccount;
 
-NS_CLASS_AVAILABLE_IOS(8_0)
 @interface SAKeyChainItemWrapper : NSObject
 
 + (NSString *)saUdid;

--- a/SensorsAnalyticsSDK/Core/SAKeyChainItemWrapper.m
+++ b/SensorsAnalyticsSDK/Core/SAKeyChainItemWrapper.m
@@ -58,7 +58,7 @@ NSString * const kSAUdidAccount = @"com.sensorsdata.analytics.udid";
     @try {
         NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
         CFTypeRef queryResults = NULL;
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
         CFErrorRef error = NULL;
         SecAccessControlRef secAccessControl =  SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleAfterFirstUnlock, kSecAccessControlUserPresence, &error);
         if (error) {
@@ -126,7 +126,7 @@ NSString * const kSAUdidAccount = @"com.sensorsdata.analytics.udid";
             [query removeObjectForKey:(__bridge id)kSecMatchLimit ];
             [query removeObjectForKey:(__bridge id)kSecReturnAttributes];
             [query removeObjectForKey:(__bridge id)kSecReturnData];
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
             [query removeObjectForKey:(__bridge id)kSecAttrAccessControl];
 #else
             @try {
@@ -151,7 +151,7 @@ NSString * const kSAUdidAccount = @"com.sensorsdata.analytics.udid";
     @try {
         NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
         CFTypeRef queryResults = NULL;
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
         CFErrorRef error = NULL;
         SecAccessControlRef secAccessControl =  SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleAfterFirstUnlock, kSecAccessControlUserPresence, &error);
         if (error) {

--- a/SensorsAnalyticsSDK/Core/SALogger/SAFileLogger.m
+++ b/SensorsAnalyticsSDK/Core/SALogger/SAFileLogger.m
@@ -87,7 +87,7 @@
         return nil;
     }
     NSDictionary *attributes = nil;
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
     attributes = [NSDictionary dictionaryWithObject:NSFileProtectionComplete forKey:NSFileProtectionKey];
 #endif
     BOOL fileCreated = [[NSFileManager defaultManager] createFileAtPath:logfilePath contents:nil attributes:attributes];

--- a/SensorsAnalyticsSDK/Core/SAModuleManager.m
+++ b/SensorsAnalyticsSDK/Core/SAModuleManager.m
@@ -99,7 +99,7 @@ static NSString * const kSAExposureModuleName = @"Exposure";
     if (configOptions.disableSDK) {
         return;
     }
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
     for (NSString *moduleName in self.moduleNames) {
         if ([moduleName isEqualToString:kSAJavaScriptBridgeModuleName]) {
             continue;

--- a/SensorsAnalyticsSDK/Core/SASwizzle.m
+++ b/SensorsAnalyticsSDK/Core/SASwizzle.m
@@ -24,7 +24,7 @@
 
 #import "SASwizzle.h"
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
 	#import <objc/runtime.h>
 	#import <objc/message.h>
 #else

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK+Private.h
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK+Private.h
@@ -22,7 +22,6 @@
 #define SensorsAnalyticsSDK_Private_h
 #import "SensorsAnalyticsSDK.h"
 #import <Foundation/Foundation.h>
-#import <WebKit/WebKit.h>
 #import "SANetwork.h"
 #import "SAHTTPSession.h"
 #import "SATrackEventObject.h"

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
@@ -1051,7 +1051,7 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
     if (self.configOptions.disableSDK) {
         return;
     }
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(remoteConfigManagerModelChanged:) name:SA_REMOTE_CONFIG_MODEL_CHANGED_NOTIFICATION object:nil];
 #endif
 }

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
@@ -238,7 +238,7 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
                 [self addRemoteConfigObservers];
             }
             
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
             [self setupSecurityPolicyWithConfigOptions:_configOptions];
             
             [SAReferrerManager sharedInstance].serialQueue = _serialQueue;
@@ -341,7 +341,7 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
     });
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
 - (void)setupSecurityPolicyWithConfigOptions:(SAConfigOptions *)options {
     SASecurityPolicy *securityPolicy = options.securityPolicy;
     if (!securityPolicy) {

--- a/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
+++ b/SensorsAnalyticsSDK/Core/SensorsAnalyticsSDK.m
@@ -143,7 +143,9 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
     [instance removeObservers];
     [instance removeWebViewUserAgent];
     
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
     [SAReachability.sharedInstance stopMonitoring];
+#endif
     
     [SAModuleManager.sharedInstance disableAllModules];
     
@@ -162,8 +164,11 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
         return;
     }
     instance.configOptions.disableSDK = NO;
+    
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
     // 部分模块和监听依赖网络状态，所以需要优先开启
     [SAReachability.sharedInstance startMonitoring];
+#endif
     
     // 优先添加远程控制监听，防止热启动时关闭 SDK 的情况下
     [instance addRemoteConfigObservers];
@@ -227,7 +232,9 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
             [self registerPropertyPlugin];
             
             if (!_configOptions.disableSDK) {
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
                 [[SAReachability sharedInstance] startMonitoring];
+#endif
                 [self addRemoteConfigObservers];
             }
             
@@ -609,8 +616,10 @@ NSString * const SensorsAnalyticsIdentityKeyEmail = @"$identity_email";
         return NO;
     }
     
+#if __has_include(<SystemConfiguration/SystemConfiguration.h>)
     // 退到后台时的网络状态变化不会监听，因此通过 handleSchemeUrl 唤醒 App 时主动获取网络状态
     [[SAReachability sharedInstance] startMonitoring];
+#endif
     
     return [SAModuleManager.sharedInstance handleURL:url];
 }

--- a/SensorsAnalyticsSDK/Store/SAFileStorePlugin.m
+++ b/SensorsAnalyticsSDK/Store/SAFileStorePlugin.m
@@ -73,7 +73,7 @@ static NSString * const kSAFileStorePluginType = @"cn.sensorsdata.File.";
         return;
     }
     NSString *filePath = [SAFileStorePlugin filePath:key];
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
     /* 为filePath文件设置保护等级 */
     NSDictionary *protection = [NSDictionary dictionaryWithObject:NSFileProtectionComplete
                                                            forKey:NSFileProtectionKey];


### PR DESCRIPTION
基本 watchOS 7+ 支持。允许 SDK 初始化和手动埋点上报，尚不兼容全自动、可视化、WebView 埋点。

### 改动

1. 非 `UIKit` 相关 iOS 平台判断（例如：Keychain、Obj-C Runtime 等）增加 watchOS 平台条件
2. `UIApplication` 相关代码添加 `WKApplication` 逻辑分支
3. `UIDevice` 相关代码添加 `WKInterfaceDevice` 逻辑分支
4. 添加 `SystemConfiguration` 框架可用性判断；SC 不可用时移除 Reachability 相关代码
5. Podspec 声明支持 watchOS；改动部分系统框架依赖声明
