### PR TITLE
Fixed an issue where PrivacyInfo.xcprivacy was not added to pod.

### DIFF
--- a/SensorsAnalyticsSDK.podspec
+++ b/SensorsAnalyticsSDK.podspec
@@ -43,6 +43,10 @@ Pod::Spec.new do |s|
     core.ios.dependency 'SensorsAnalyticsSDK/Visualized'
     core.osx.dependency 'SensorsAnalyticsSDK/Common'
     core.tvos.dependency 'SensorsAnalyticsSDK/Base'
+
+    core.resource_bundle = {
+      'SensorsAnalyticsSDK' => [ 'SensorsAnalyticsSDK/Core/PrivacyInfo.xcprivacy' ]
+    }
   end
 
   # 全埋点

--- a/SensorsAnalyticsSDK.podspec
+++ b/SensorsAnalyticsSDK.podspec
@@ -14,6 +14,10 @@ Pod::Spec.new do |s|
 
   s.libraries = 'icucore', 'z'
 
+  s.resource_bundle = {
+    'SensorsAnalyticsSDK' => [ 'SensorsAnalyticsSDK/Core/PrivacyInfo.xcprivacy' ]
+  }
+
   s.subspec '__Store' do |store|
     store.source_files = 'SensorsAnalyticsSDK/Store/*.{h,m}'
     store.public_header_files = 'SensorsAnalyticsSDK/Store/SABaseStoreManager.h', 'SensorsAnalyticsSDK/Store/SAStorePlugin.h', 'SensorsAnalyticsSDK/Store/SAAESStorePlugin.h'
@@ -43,10 +47,6 @@ Pod::Spec.new do |s|
     core.ios.dependency 'SensorsAnalyticsSDK/Visualized'
     core.osx.dependency 'SensorsAnalyticsSDK/Common'
     core.tvos.dependency 'SensorsAnalyticsSDK/Base'
-
-    core.resource_bundle = {
-      'SensorsAnalyticsSDK' => [ 'SensorsAnalyticsSDK/Core/PrivacyInfo.xcprivacy' ]
-    }
   end
 
   # 全埋点


### PR DESCRIPTION
You only added `PrivacyInfo.xcprivacy` to the source code path, but did not add it to the podspec file. This commit fixes this issue.

It’s also worth mentioning that CocoaPods’ support for `PrivacyInfo.xcprivacy` is currently uncertain and unverified (because Apple has not yet begun to strictly enforce this requirement). refer to: [[New Feature / Proposal] Add new required attribute in podspec to provide privacy details](https://github.com/CocoaPods/CocoaPods/issues/10325).

It is recommended to add Swift Package Manager support as soon as possible. I'm working on this, but I'm not sure how long I'll have to do it, or even if it will eventually be done.

Because of the stagnant performance of the CocoaPods team, the `PrivacyInfo.xcprivacy` requirement may prompt an accelerated migration to the Swift Package Manager. It is recommended that you make plans as early as possible.